### PR TITLE
Use YAML config for training parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,21 @@ bash run_unix.sh
 > - Windows: C:\Users\<USER>\.kaggle\kaggle.json
 > - Mac/Linux: ~/.kaggle/kaggle.json
 > أو في جذر المشروع وسيُنقل تلقائيًا.
+
+## إعدادات التدريب
+يمكن تعديل هايبر باراميترز التدريب من خلال ملف `model_config.yml`:
+
+```yaml
+data_dir: "data/clean256"
+batch_size: 64
+epochs: 20
+patience: 5
+learning_rate: 0.0003
+weight_decay: 0.0001
+backbones:
+  - efficientnet_b0
+  - convnext_tiny
+  - swin_tiny_patch4_window7_224
+```
+
+أي حقل يُحذف من الملف سيُستَخدَم له القيم الافتراضية الموجودة في الكود.


### PR DESCRIPTION
## Summary
- load `model_config.yml` with `yaml.safe_load` and default fallbacks
- drive training hyperparameters and backbone list from the config file
- document configurable options in the README

## Testing
- `python -m py_compile train_multi.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0f90e61088325950cfe754df1a195