### PR TITLE
Handle missing dependencies with explicit errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,12 +17,19 @@ def health():
 @app.post("/download")
 def download_all(skip_if_exists: bool = True):
     """ينزّل كل الـ datasets من datasets_catalog.json"""
-    ensure_pkg("kaggle")
+    try:
+        ensure_pkg("kaggle")
+    except ImportError as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
+
     ensure_kaggle_token()
 
     catalog = json.loads(Path("datasets_catalog.json").read_text(encoding="utf-8"))
     for item in catalog:
-        kaggle_download(item["slug"], item["dest"], skip_if_exists=skip_if_exists)
+        try:
+            kaggle_download(item["slug"], item["dest"], skip_if_exists=skip_if_exists)
+        except ImportError as e:
+            return JSONResponse({"ok": False, "error": str(e)}, status_code=500)
     return {"ok": True, "message": "Downloaded/checked datasets."}
 
 @app.post("/prepare")

--- a/utils_kaggle.py
+++ b/utils_kaggle.py
@@ -2,10 +2,21 @@ import os, json, stat, subprocess, sys
 from pathlib import Path
 
 def ensure_pkg(pkg: str):
+    """Ensure that ``pkg`` is importable.
+
+    If the package cannot be imported, an :class:`ImportError` is raised with
+    a message instructing the user to install the dependency manually. This
+    avoids implicitly installing packages at runtime and gives clearer feedback
+    to the caller.
+    """
+
     try:
         __import__(pkg)
-    except ImportError:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", pkg])
+    except ImportError as e:
+        raise ImportError(
+            f"Required package '{pkg}' is not installed. Please install it manually"
+            f" (e.g., 'pip install {pkg}')."
+        ) from e
 
 def ensure_kaggle_token() -> None:
     home = Path.home()


### PR DESCRIPTION
## Summary
- Raise a clear ImportError in `ensure_pkg` instead of silently installing packages
- Surface missing-package errors in `/download` endpoint so users can install `kaggle` manually

## Testing
- `python -m py_compile utils_kaggle.py app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0f907fa4c832581ba3694a9799761