### PR TITLE
Handle missing artifact files during inference

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,7 +46,10 @@ def train():
 async def predict(file: UploadFile = File(...), topk: int = Query(3, ge=1, le=10)):
     """تنبؤ بصورة واحدة (ارفع ملف صورة) — يرجع أفضل topk تصنيفات"""
     image_bytes = await file.read()
-    preds, best = predict_bytes(image_bytes, topk=topk)
+    try:
+        preds, best = predict_bytes(image_bytes, topk=topk)
+    except FileNotFoundError as e:
+        return JSONResponse({"ok": False, "error": str(e)}, status_code=404)
     return {"ok": True, "backbone": best["model"], "predictions": preds}
 
 @app.get("/labels")

--- a/infer.py
+++ b/infer.py
@@ -11,7 +11,13 @@ DEVICE = 'cuda' if torch.cuda.is_available() else 'cpu'
 def load_best():
     results_path = Path("artifacts/finetune_results.json")
     labels_path  = Path("artifacts/labels.json")
-    assert results_path.exists() and labels_path.exists(), "لم يتم العثور على نتائج التدريب/الملصقات."
+    missing = []
+    if not results_path.exists():
+        missing.append("finetune_results.json")
+    if not labels_path.exists():
+        missing.append("labels.json")
+    if missing:
+        raise FileNotFoundError(f"Missing file(s): {', '.join(missing)}. درب النموذج أولاً.")
 
     results = json.loads(results_path.read_text(encoding="utf-8"))
     best = results[0]


### PR DESCRIPTION
## Summary
- Raise `FileNotFoundError` when inference artifacts are missing
- Return a 404 response from `/predict` when artifacts are not found

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0f90abe1483259da8be5515d43c1e