### PR TITLE
feat: add GitHub user endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ onnx
 onnxruntime
 pyyaml
 python-multipart
+httpx


### PR DESCRIPTION
## Summary
- add `/github-user` API endpoint to return authenticated GitHub user info
- require `httpx` for GitHub API requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0fbcaec0483259604308ab4c43938